### PR TITLE
NK-67 Updated gperftools build image, in order to build gperftools.

### DIFF
--- a/solvent.manifest
+++ b/solvent.manifest
@@ -1,3 +1,3 @@
 requirements:
-- hash: 37218f7dbc08f703279a4e84d8b4dfba77b7bd50
+- hash: 55b2607abb75e85114b912ff821c1e5995a5799c
   originURL: https://github.com/Stratoscale/rootfs-clean-build.git


### PR DESCRIPTION
Updated gperftools build image hash to be newer one (in order to build gperftools and push it to osmosis).